### PR TITLE
use pmap instead of @parallel

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4.1
+SparseVectors
 ParallelSparseMatMul
 MAT

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -3,6 +3,10 @@ module RecSys
 using ParallelSparseMatMul
 using MAT
 
+if isless(Base.VERSION, v"0.5.0-")
+    using SparseVectors
+end
+
 import Base: zero
 
 export FileSpec, DlmFile, MatFile, SparseMat, read_input

--- a/src/als-wr.jl
+++ b/src/als-wr.jl
@@ -187,13 +187,15 @@ function fact_iters(_U::Matrix{Float64}, _P::Matrix{Float64}, _R::RatingMatrix, 
 
     for iter in 1:niters
         logmsg("begin iteration $iter")
-        @parallel (noop) for u in 1:nusers
-            update_user(u)
-        end
+        pmap(update_user, 1:nusers)
+        #@parallel (noop) for u in 1:nusers
+        #    update_user(u)
+        #end
         logmsg("\tusers")
-        @parallel (noop) for i in 1:nitems
-            update_item(i)
-        end
+        pmap(update_item, 1:nitems)
+        #@parallel (noop) for i in 1:nitems
+        #    update_item(i)
+        #end
         logmsg("\titems")
     end
 


### PR DESCRIPTION
`@parallel` results in imbalanced work partitions because each iteration may be of different size and the input data may inadvertently be sorted in a manner that penalizes only some workers.

`pmap` schedules each task dynamically and hence will result in a uniform distribution. The additional overhead of pmap can be ignored for large problems, which would be most of the practical workload.

An alternative (not explored here) would be to partition the workload separately and use either `pmap` or `@parallel` just to execute it.

Also added missing `SparseVectors` package dependency on Julia 0.4.