### PR TITLE
abstractions for input and model (preparing for distributed impl.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
-language: cpp
-compiler:
-  - clang
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - release
+  - nightly
 notifications:
   email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("JuliaRecSys"))`); Pkg.pin("JuliaRecSys"); Pkg.resolve()'
-  - julia -e 'using JuliaRecSys; @assert isdefined(:JuliaRecSys); @assert typeof(JuliaRecSys) === Module'
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("RecSys"); Pkg.test("RecSys"; coverage=true)'

--- a/examples/lastfm/lastfm.jl
+++ b/examples/lastfm/lastfm.jl
@@ -10,7 +10,7 @@ type MusicRec
     trainingset::FileSpec
     artist_names::FileSpec
     artist_map::FileSpec
-    rec::ALSWR
+    als::ALSWR
     artist_mat::Nullable{Dict{Int64,AbstractString}}
 
     function MusicRec(trainingset::FileSpec, artist_names::FileSpec, artist_map::FileSpec)
@@ -92,9 +92,9 @@ function artist_names(rec::MusicRec)
     get(rec.artist_mat)
 end
 
-train(musicrec::MusicRec, args...) = train(musicrec.rec, args...)
-rmse(musicrec::MusicRec) = rmse(musicrec.rec)
-recommend(musicrec::MusicRec, args...; kwargs...) = recommend(musicrec.rec, args...; kwargs...)
+train(musicrec::MusicRec, args...) = train(musicrec.als, args...)
+rmse(musicrec::MusicRec) = rmse(musicrec.als)
+recommend(musicrec::MusicRec, args...; kwargs...) = recommend(musicrec.als, args...; kwargs...)
 
 function print_list(mat::Dict, idxs::Vector{Int}, header::AbstractString)
     if !isempty(idxs)
@@ -129,16 +129,18 @@ function test(dataset_path)
     print_recommendations(rec, recommend(rec, 9875)...)
 
     println("recommending anonymous user:")
-    u_idmap = RecSys.user_idmap(rec.rec.inp)
-    i_idmap = RecSys.item_idmap(rec.rec.inp)
+    u_idmap = RecSys.user_idmap(rec.als.inp)
+    i_idmap = RecSys.item_idmap(rec.als.inp)
     # take user 9875
     actual_user = findfirst(u_idmap, 9875)
-    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.rec.inp, actual_user)
+    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.als.inp, actual_user)
     actual_movie_ids = i_idmap[rated_anon]
     sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")
+    clear(rec.als)
+    localize!(rec.als)
     save(rec, "model.sav")
     nothing
 end

--- a/examples/lastfm/lastfm.jl
+++ b/examples/lastfm/lastfm.jl
@@ -132,10 +132,11 @@ function test(dataset_path)
     u_idmap = RecSys.user_idmap(rec.als.inp)
     i_idmap = RecSys.item_idmap(rec.als.inp)
     # take user 9875
-    actual_user = findfirst(u_idmap, 9875)
+    actual_user = isempty(u_idmap) ? 9875 : findfirst(u_idmap, 9875)
     rated_anon, ratings_anon = RecSys.items_and_ratings(rec.als.inp, actual_user)
-    actual_movie_ids = i_idmap[rated_anon]
-    sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
+    actual_music_ids = isempty(i_idmap) ? rated_anon : i_idmap[rated_anon]
+    nmusic = isempty(i_idmap) ? RecSys.nitems(rec.als.inp) : maximum(i_idmap)
+    sp_ratings_anon = SparseVector(nmusic, actual_music_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")

--- a/examples/lastfm/lastfm.jl
+++ b/examples/lastfm/lastfm.jl
@@ -129,12 +129,13 @@ function test(dataset_path)
     print_recommendations(rec, recommend(rec, 9875)...)
 
     println("recommending anonymous user:")
-    R, item_idmap, user_idmap = RecSys.ratings(rec.rec)
-    # take user 100
-    actual_user = findfirst(user_idmap, 9875)
-    ratings_anon = R[actual_user, :]
-    actual_movie_ids = item_idmap[find(full(ratings_anon))]
-    sp_ratings_anon = SparseVector(maximum(item_idmap), actual_movie_ids, nonzeros(ratings_anon))
+    u_idmap = RecSys.user_idmap(rec.rec.inp)
+    i_idmap = RecSys.item_idmap(rec.rec.inp)
+    # take user 9875
+    actual_user = findfirst(u_idmap, 9875)
+    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.rec.inp, actual_user)
+    actual_movie_ids = i_idmap[rated_anon]
+    sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")

--- a/examples/movielens/movielens.jl
+++ b/examples/movielens/movielens.jl
@@ -8,7 +8,7 @@ end
 
 type MovieRec
     movie_names::FileSpec
-    rec::ALSWR
+    als::ALSWR
     movie_mat::Nullable{SparseVector{AbstractString,Int64}}
 
     function MovieRec(trainingset::FileSpec, movie_names::FileSpec)
@@ -30,9 +30,9 @@ function movie_names(rec::MovieRec)
     get(rec.movie_mat)
 end
 
-train(movierec::MovieRec, args...) = train(movierec.rec, args...)
-rmse(movierec::MovieRec, args...; kwargs...) = rmse(movierec.rec, args...; kwargs...)
-recommend(movierec::MovieRec, args...; kwargs...) = recommend(movierec.rec, args...; kwargs...)
+train(movierec::MovieRec, args...) = train(movierec.als, args...)
+rmse(movierec::MovieRec, args...; kwargs...) = rmse(movierec.als, args...; kwargs...)
+recommend(movierec::MovieRec, args...; kwargs...) = recommend(movierec.als, args...; kwargs...)
 
 function print_list(mat::SparseVector, idxs::Vector{Int}, header::AbstractString)
     if isless(Base.VERSION, v"0.5.0-")
@@ -69,16 +69,18 @@ function test(dataset_path)
     print_recommendations(rec, recommend(rec, 100)...)
 
     println("recommending anonymous user:")
-    u_idmap = RecSys.user_idmap(rec.rec.inp)
-    i_idmap = RecSys.item_idmap(rec.rec.inp)
+    u_idmap = RecSys.user_idmap(rec.als.inp)
+    i_idmap = RecSys.item_idmap(rec.als.inp)
     # take user 100
     actual_user = findfirst(u_idmap, 100)
-    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.rec.inp, actual_user)
+    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.als.inp, actual_user)
     actual_movie_ids = i_idmap[rated_anon]
     sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")
+    clear(rec.als)
+    localize!(rec.als)
     save(rec, "model.sav")
     nothing
 end

--- a/examples/movielens/movielens.jl
+++ b/examples/movielens/movielens.jl
@@ -69,12 +69,13 @@ function test(dataset_path)
     print_recommendations(rec, recommend(rec, 100)...)
 
     println("recommending anonymous user:")
-    R, item_idmap, user_idmap = RecSys.ratings(rec.rec)
+    u_idmap = RecSys.user_idmap(rec.rec.inp)
+    i_idmap = RecSys.item_idmap(rec.rec.inp)
     # take user 100
-    actual_user = findfirst(user_idmap, 100)
-    ratings_anon = R[actual_user, :]
-    actual_movie_ids = item_idmap[find(full(ratings_anon))]
-    sp_ratings_anon = SparseVector(maximum(item_idmap), actual_movie_ids, nonzeros(ratings_anon))
+    actual_user = findfirst(u_idmap, 100)
+    rated_anon, ratings_anon = RecSys.items_and_ratings(rec.rec.inp, actual_user)
+    actual_movie_ids = i_idmap[rated_anon]
+    sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")

--- a/examples/movielens/movielens.jl
+++ b/examples/movielens/movielens.jl
@@ -72,10 +72,11 @@ function test(dataset_path)
     u_idmap = RecSys.user_idmap(rec.als.inp)
     i_idmap = RecSys.item_idmap(rec.als.inp)
     # take user 100
-    actual_user = findfirst(u_idmap, 100)
+    actual_user = isempty(u_idmap) ? 100 : findfirst(u_idmap, 100)
     rated_anon, ratings_anon = RecSys.items_and_ratings(rec.als.inp, actual_user)
-    actual_movie_ids = i_idmap[rated_anon]
-    sp_ratings_anon = SparseVector(maximum(i_idmap), actual_movie_ids, ratings_anon)
+    actual_movie_ids = isempty(i_idmap) ? rated_anon : i_idmap[rated_anon]
+    nmovies = isempty(i_idmap) ? RecSys.nitems(rec.als.inp) : maximum(i_idmap)
+    sp_ratings_anon = SparseVector(nmovies, actual_movie_ids, ratings_anon)
     print_recommendations(rec, recommend(rec, sp_ratings_anon)...)
 
     println("saving model to model.sav")

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -12,7 +12,7 @@ import Base: zero
 export FileSpec, DlmFile, MatFile, SparseMat, read_input
 export ALSWR, train, recommend, rmse, zero
 export ParShmem
-export save, load
+export save, load, clear, localize!
 
 typealias RatingMatrix SparseMatrixCSC{Float64,Int64}
 typealias SharedRatingMatrix ParallelSparseMatMul.SharedSparseMatrixCSC{Float64,Int64}

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -31,6 +31,9 @@ if (Base.VERSION >= v"0.5.0-")
 using Base.Threads
 type ParThread <: Parallelism end
 export ParThread
+else
+macro threads(x)
+end
 end
 
 include("input.jl")
@@ -39,10 +42,10 @@ include("als-wr.jl")
 include("utils.jl")
 
 # enable logging only during debugging
-using Logging
-#const logger = Logging.configure(filename="recsys.log", level=DEBUG)
-const logger = Logging.configure(level=DEBUG)
-logmsg(s) = debug(s)
-#logmsg(s) = nothing
+#using Logging
+##const logger = Logging.configure(filename="recsys.log", level=DEBUG)
+#const logger = Logging.configure(level=DEBUG)
+#logmsg(s) = debug(s)
+logmsg(s) = nothing
 
 end

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -8,6 +8,7 @@ if isless(Base.VERSION, v"0.5.0-")
 end
 
 import Base: zero
+import ParallelSparseMatMul: share
 
 export FileSpec, DlmFile, MatFile, SparseMat, read_input
 export ALSWR, train, recommend, rmse, zero
@@ -16,6 +17,8 @@ export save, load
 
 typealias RatingMatrix SparseMatrixCSC{Float64,Int64}
 typealias SharedRatingMatrix ParallelSparseMatMul.SharedSparseMatrixCSC{Float64,Int64}
+typealias InputRatings Union{RatingMatrix,SharedRatingMatrix}
+typealias InputIdMap Union{Vector{Int64}, SharedVector{Int64}}
 abstract FileSpec
 
 abstract Parallelism
@@ -27,6 +30,7 @@ type ParThread <: Parallelism end
 export ParThread
 end
 
+include("input.jl")
 include("als-wr.jl")
 include("utils.jl")
 

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -19,7 +19,10 @@ typealias SharedRatingMatrix ParallelSparseMatMul.SharedSparseMatrixCSC{Float64,
 typealias InputRatings Union{RatingMatrix,SharedRatingMatrix}
 typealias InputIdMap Union{Vector{Int64}, SharedVector{Int64}}
 typealias ModelFactor Union{Matrix{Float64}, SharedArray{Float64,2}}
+
 abstract FileSpec
+abstract Inputs
+abstract Model
 
 abstract Parallelism
 type ParShmem <: Parallelism end

--- a/src/RecSys.jl
+++ b/src/RecSys.jl
@@ -8,7 +8,6 @@ if isless(Base.VERSION, v"0.5.0-")
 end
 
 import Base: zero
-import ParallelSparseMatMul: share
 
 export FileSpec, DlmFile, MatFile, SparseMat, read_input
 export ALSWR, train, recommend, rmse, zero
@@ -19,6 +18,7 @@ typealias RatingMatrix SparseMatrixCSC{Float64,Int64}
 typealias SharedRatingMatrix ParallelSparseMatMul.SharedSparseMatrixCSC{Float64,Int64}
 typealias InputRatings Union{RatingMatrix,SharedRatingMatrix}
 typealias InputIdMap Union{Vector{Int64}, SharedVector{Int64}}
+typealias ModelFactor Union{Matrix{Float64}, SharedArray{Float64,2}}
 abstract FileSpec
 
 abstract Parallelism
@@ -31,6 +31,7 @@ export ParThread
 end
 
 include("input.jl")
+include("als_model.jl")
 include("als-wr.jl")
 include("utils.jl")
 

--- a/src/als-wr.jl
+++ b/src/als-wr.jl
@@ -40,6 +40,12 @@ type Inputs
     end
 end
 
+function clear(inp::Inputs)
+    inp.R = nothing
+    inp.item_idmap = nothing
+    inp.user_idmap = nothing
+end
+
 type Model
     U::Matrix{Float64}
     P::Matrix{Float64}
@@ -53,6 +59,14 @@ type ALSWR{T<:Parallelism}
 end
 
 ALSWR{T<:Parallelism}(inp::FileSpec, par::T=ParShmem()) = ALSWR{T}(Inputs(inp), nothing, par)
+
+function save(model::ALSWR, filename::AbstractString)
+    clear(model.inp)
+    open(filename, "w") do f
+        serialize(f, model)
+    end
+    nothing
+end
 
 ratings(als::ALSWR) = ratings(als.inp)
 function ratings(inp::Inputs; only_items::Vector{Int64}=Int64[])

--- a/src/als-wr.jl
+++ b/src/als-wr.jl
@@ -6,10 +6,20 @@ end
 
 ALSWR{TP<:Parallelism}(inp::FileSpec, par::TP=ParShmem()) = ALSWR{TP,SharedMemoryInputs,SharedMemoryModel}(SharedMemoryInputs(inp), nothing, par)
 
-function save(model::ALSWR, filename::AbstractString)
-    clear(model.inp)
+function clear(als::ALSWR)
+    clear(als.inp)
+    isnull(als.model) || clear(get(als.model))
+end
+
+function localize!(als::ALSWR)
+    localize!(als.inp)
+    isnull(als.model) || localize!(get(als.model))
+end
+
+function save(als::ALSWR, filename::AbstractString)
+    clear(als)
     open(filename, "w") do f
-        serialize(f, model)
+        serialize(f, als)
     end
     nothing
 end

--- a/src/als_model.jl
+++ b/src/als_model.jl
@@ -1,0 +1,86 @@
+type Model
+    U::ModelFactor
+    P::ModelFactor
+    nfactors::Int
+    lambda::Float64
+    lambdaI::Nullable{ModelFactor}
+    Pinv::Nullable{ModelFactor}
+end
+
+nusers(model::Model) = size(model.U, 1)
+nitems(model::Model) = size(model.P, 2)
+nfactors(model::Model) = model.nfactors
+
+function share!(model::Model)
+    isa(model.U, SharedArray) || (model.U = share(model.U))
+    isa(model.P, SharedArray) || (model.P = share(model.P))
+
+    lambdaI = get(model.lambdaI)
+    isa(lambdaI, SharedArray) || (model.lambdaI = share(lambdaI))
+
+    if !isnull(model.Pinv)
+        Pinv = get(model.Pinv)
+        isa(Pinv, SharedArray) || (model.Pinv = share(Pinv))
+    end
+    nothing
+end
+
+function localize!(model::Model)
+    isa(model.U, SharedArray) && (model.U = copy(model.U))
+    isa(model.P, SharedArray) && (model.P = copy(model.P))
+    nothing
+end
+
+function clear(model::Model)
+    model.lambdaI = nothing
+    model.Pinv = nothing
+end
+
+function pinv(model::Model)
+    if isnull(model.Pinv)
+        # since: I = (P * Pt) * inv(P * Pt)
+        # Pinv = Pt * inv(P * Pt)
+        P = model.P
+        PT = P'
+        model.Pinv = PT * inv(P * PT)
+    end
+    get(model.Pinv)
+end
+
+vec_mul_p(model::Model, v) = v * model.P
+vec_mul_pinv(model::Model, v) = v * pinv(model)
+
+function prep(inp::Inputs, nfacts::Int, lambda::Float64)
+    ensure_loaded(inp)
+    t1 = time()
+    logmsg("preparing inputs...")
+
+    nu = nusers(inp)
+    ni = nitems(inp)
+
+    U = zeros(nu, nfacts)
+    P = rand(nfacts, ni)
+    for idx in 1:ni
+        P[1,idx] = mean(all_user_ratings(inp, idx))
+    end
+
+    lambdaI = lambda * eye(nfacts)
+    model = Model(U, P, nfacts, lambda, lambdaI, nothing)
+
+    t2 = time()
+    logmsg("prep time: $(t2-t1)")
+    model
+end
+
+@inline function setU(model::Model, u::Int64, vals)
+    model.U[u,:] = vals
+    nothing
+end
+
+@inline function setP(model::Model, i::Int64, vals)
+    model.P[:,i] = vals
+    nothing
+end
+
+getU(model::Model, users) = model.U[users, :]
+getP(model::Model, items) = model.P[:, items]

--- a/src/input.jl
+++ b/src/input.jl
@@ -41,17 +41,25 @@ function localize!(inp::SharedMemoryInputs)
 end
 
 function share!(inp::SharedMemoryInputs)
-    R = get(inp.R)
-    isa(R, SharedRatingMatrix) || (inp.R = share(R))
+    if !isnull(inp.R)
+        R = get(inp.R)
+        isa(R, SharedRatingMatrix) || (inp.R = share(R))
+    end
 
-    RT = get(inp.RT)
-    isa(RT, SharedRatingMatrix) || (inp.RT = share(RT))
+    if !isnull(inp.RT)
+        RT = get(inp.RT)
+        isa(RT, SharedRatingMatrix) || (inp.RT = share(RT))
+    end
 
-    item_idmap = get(inp.item_idmap)
-    isa(item_idmap, SharedVector) || (inp.item_idmap = share(item_idmap))
+    if !isnull(inp.item_idmap)
+        item_idmap = get(inp.item_idmap)
+        isa(item_idmap, SharedVector) || (inp.item_idmap = share(item_idmap))
+    end
 
-    user_idmap = get(inp.user_idmap)
-    isa(user_idmap, SharedVector) || (inp.user_idmap = share(user_idmap))
+    if !isnull(inp.user_idmap)
+        user_idmap = get(inp.user_idmap)
+        isa(user_idmap, SharedVector) || (inp.user_idmap = share(user_idmap))
+    end
 
     nothing
 end

--- a/src/input.jl
+++ b/src/input.jl
@@ -1,23 +1,23 @@
-type Inputs
+type SharedMemoryInputs <: Inputs
     ratings_file::FileSpec
     R::Nullable{InputRatings}
     RT::Nullable{InputRatings}
     item_idmap::Nullable{InputIdMap}
     user_idmap::Nullable{InputIdMap}
 
-    function Inputs(file::FileSpec)
+    function SharedMemoryInputs(file::FileSpec)
         new(file, nothing, nothing, nothing, nothing)
     end
 end
 
-function clear(inp::Inputs)
+function clear(inp::SharedMemoryInputs)
     inp.R = nothing
     inp.RT = nothing
     inp.item_idmap = nothing
     inp.user_idmap = nothing
 end
 
-function share!(inp::Inputs)
+function share!(inp::SharedMemoryInputs)
     R = get(inp.R)
     isa(R, SharedRatingMatrix) || (inp.R = share(R))
 
@@ -64,7 +64,7 @@ function filter_empty(R::RatingMatrix; only_items::Vector{Int64}=Int64[])
     R, non_empty_items, non_empty_users
 end
 
-function ensure_loaded(inp::Inputs; only_items::Vector{Int64}=Int64[])
+function ensure_loaded(inp::SharedMemoryInputs; only_items::Vector{Int64}=Int64[])
     if isnull(inp.R)
         logmsg("loading inputs...")
         t1 = time()
@@ -93,19 +93,19 @@ function ensure_loaded(inp::Inputs; only_items::Vector{Int64}=Int64[])
     nothing
 end
 
-item_idmap(inp::Inputs) = get(inp.item_idmap)
-user_idmap(inp::Inputs) = get(inp.user_idmap)
+item_idmap(inp::SharedMemoryInputs) = get(inp.item_idmap)
+user_idmap(inp::SharedMemoryInputs) = get(inp.user_idmap)
 
-nusers(inp::Inputs) = size(get(inp.R), 1)
-nitems(inp::Inputs) = size(get(inp.R), 2)
+nusers(inp::SharedMemoryInputs) = size(get(inp.R), 1)
+nitems(inp::SharedMemoryInputs) = size(get(inp.R), 2)
 
-users_and_ratings(inp::Inputs, i::Int64) = _sprowsvals(get(inp.R), i)
-all_user_ratings(inp::Inputs, i::Int64) = _spvals(get(inp.R), i)
-all_users_rated(inp::Inputs, i::Int64) = _sprows(get(inp.R), i)
+users_and_ratings(inp::SharedMemoryInputs, i::Int64) = _sprowsvals(get(inp.R), i)
+all_user_ratings(inp::SharedMemoryInputs, i::Int64) = _spvals(get(inp.R), i)
+all_users_rated(inp::SharedMemoryInputs, i::Int64) = _sprows(get(inp.R), i)
 
-items_and_ratings(inp::Inputs, u::Int64) = _sprowsvals(get(inp.RT), u)
-all_item_ratings(inp::Inputs, u::Int64) = _spvals(get(inp.RT), u)
-all_items_rated(inp::Inputs, u::Int64) = _sprows(get(inp.RT), u)
+items_and_ratings(inp::SharedMemoryInputs, u::Int64) = _sprowsvals(get(inp.RT), u)
+all_item_ratings(inp::SharedMemoryInputs, u::Int64) = _spvals(get(inp.RT), u)
+all_items_rated(inp::SharedMemoryInputs, u::Int64) = _sprows(get(inp.RT), u)
 
 function _sprowsvals(R::InputRatings, col::Int64)
     rowstart = R.colptr[col]

--- a/src/input.jl
+++ b/src/input.jl
@@ -17,6 +17,29 @@ function clear(inp::SharedMemoryInputs)
     inp.user_idmap = nothing
 end
 
+function localize!(inp::SharedMemoryInputs)
+    if !isnull(inp.R)
+        R = get(inp.R)
+        isa(R, SharedRatingMatrix) && (inp.R = copy(R))
+    end
+
+    if !isnull(inp.RT)
+        RT = get(inp.RT)
+        isa(RT, SharedRatingMatrix) && (inp.RT = copy(RT))
+    end
+
+    if !isnull(inp.item_idmap)
+        item_idmap = get(inp.item_idmap)
+        isa(item_idmap, SharedVector) && (inp.item_idmap = copy(item_idmap))
+    end
+
+    if !isnull(inp.user_idmap)
+        user_idmap = get(inp.user_idmap)
+        isa(user_idmap, SharedVector) && (inp.user_idmap = copy(user_idmap))
+    end
+    nothing
+end
+
 function share!(inp::SharedMemoryInputs)
     R = get(inp.R)
     isa(R, SharedRatingMatrix) || (inp.R = share(R))

--- a/src/input.jl
+++ b/src/input.jl
@@ -17,7 +17,7 @@ function clear(inp::Inputs)
     inp.user_idmap = nothing
 end
 
-function share(inp::Inputs)
+function share!(inp::Inputs)
     R = get(inp.R)
     isa(R, SharedRatingMatrix) || (inp.R = share(R))
 

--- a/src/input.jl
+++ b/src/input.jl
@@ -1,0 +1,129 @@
+type Inputs
+    ratings_file::FileSpec
+    R::Nullable{InputRatings}
+    RT::Nullable{InputRatings}
+    item_idmap::Nullable{InputIdMap}
+    user_idmap::Nullable{InputIdMap}
+
+    function Inputs(file::FileSpec)
+        new(file, nothing, nothing, nothing, nothing)
+    end
+end
+
+function clear(inp::Inputs)
+    inp.R = nothing
+    inp.RT = nothing
+    inp.item_idmap = nothing
+    inp.user_idmap = nothing
+end
+
+function share(inp::Inputs)
+    R = get(inp.R)
+    isa(R, SharedRatingMatrix) || (inp.R = share(R))
+
+    RT = get(inp.RT)
+    isa(RT, SharedRatingMatrix) || (inp.RT = share(RT))
+
+    item_idmap = get(inp.item_idmap)
+    isa(item_idmap, SharedVector) || (inp.item_idmap = share(item_idmap))
+
+    user_idmap = get(inp.user_idmap)
+    isa(user_idmap, SharedVector) || (inp.user_idmap = share(user_idmap))
+
+    nothing
+end
+
+# Note:
+# Filtering out causes the item and user ids to change.
+# We need to keep a mapping to be able to match in the recommend step.
+function filter_empty(R::RatingMatrix; only_items::Vector{Int64}=Int64[])
+    if !isempty(only_items)
+        max_num_items = maximum(only_items)
+        if size(R, 2) < max_num_items
+            RI, RJ, RV = findnz(R)
+            R = sparse(RI, RJ, RV, size(R, 1), max_num_items)
+        end
+        R = R'
+        R = R[only_items, :]
+        R = R'
+        non_empty_items = only_items
+    end
+
+    U = sum(R, 2)
+    non_empty_users = find(U)
+    R = R[non_empty_users, :]
+
+    if isempty(only_items)
+        R = R'
+        P = sum(R, 2)
+        non_empty_items = find(P)
+        R = R[non_empty_items, :]
+        R = R'
+    end
+
+    R, non_empty_items, non_empty_users
+end
+
+function ensure_loaded(inp::Inputs; only_items::Vector{Int64}=Int64[])
+    if isnull(inp.R)
+        logmsg("loading inputs...")
+        t1 = time()
+        A = read_input(inp.ratings_file)
+
+        if isa(A, SparseMatrixCSC)
+            R = convert(SparseMatrixCSC{Float64,Int64}, A)
+        else
+            # separate the columns and make them of appropriate types
+            users   = convert(Vector{Int64},   A[:,1])
+            items   = convert(Vector{Int64},   A[:,2])
+            ratings = convert(Vector{Float64}, A[:,3])
+
+            # create a sparse matrix
+            R = sparse(users, items, ratings)
+        end
+
+        R, item_idmap, user_idmap = filter_empty(R; only_items=only_items)
+        inp.R = Nullable(R)
+        inp.item_idmap = Nullable(item_idmap)
+        inp.user_idmap = Nullable(user_idmap)
+        inp.RT = Nullable(R')
+        t2 = time()
+        logmsg("time to load inputs: $(t2-t1) secs")
+    end
+    nothing
+end
+
+item_idmap(inp::Inputs) = get(inp.item_idmap)
+user_idmap(inp::Inputs) = get(inp.user_idmap)
+
+nusers(inp::Inputs) = size(get(inp.R), 1)
+nitems(inp::Inputs) = size(get(inp.R), 2)
+
+users_and_ratings(inp::Inputs, i::Int64) = _sprowsvals(get(inp.R), i)
+all_user_ratings(inp::Inputs, i::Int64) = _spvals(get(inp.R), i)
+all_users_rated(inp::Inputs, i::Int64) = _sprows(get(inp.R), i)
+
+items_and_ratings(inp::Inputs, u::Int64) = _sprowsvals(get(inp.RT), u)
+all_item_ratings(inp::Inputs, u::Int64) = _spvals(get(inp.RT), u)
+all_items_rated(inp::Inputs, u::Int64) = _sprows(get(inp.RT), u)
+
+function _sprowsvals(R::InputRatings, col::Int64)
+    rowstart = R.colptr[col]
+    rowend = R.colptr[col+1] - 1
+    # use subarray?
+    R.rowval[rowstart:rowend], R.nzval[rowstart:rowend]
+end
+
+function _sprows(R::InputRatings, col::Int64)
+    rowstart = R.colptr[col]
+    rowend = R.colptr[col+1] - 1
+    # use subarray?
+    R.rowval[rowstart:rowend]
+end
+
+function _spvals(R::InputRatings, col::Int64)
+    rowstart = R.colptr[col]
+    rowend = R.colptr[col+1] - 1
+    # use subarray?
+    R.nzval[rowstart:rowend]
+end

--- a/src/input.jl
+++ b/src/input.jl
@@ -106,18 +106,20 @@ function ensure_loaded(inp::SharedMemoryInputs; only_items::Vector{Int64}=Int64[
         end
 
         R, item_idmap, user_idmap = filter_empty(R; only_items=only_items)
-        inp.R = Nullable(R)
-        inp.item_idmap = Nullable(item_idmap)
-        inp.user_idmap = Nullable(user_idmap)
-        inp.RT = Nullable(R')
+        inp.R = R
+        inp.item_idmap = (extrema(item_idmap) == (1,length(item_idmap))) ? nothing : item_idmap
+        inp.user_idmap = (extrema(user_idmap) == (1,length(user_idmap))) ? nothing : user_idmap
+        inp.RT = R'
         t2 = time()
+        isnull(inp.item_idmap) && logmsg("no need to map item_ids")
+        isnull(inp.user_idmap) && logmsg("no need to map user_ids")
         logmsg("time to load inputs: $(t2-t1) secs")
     end
     nothing
 end
 
-item_idmap(inp::SharedMemoryInputs) = get(inp.item_idmap)
-user_idmap(inp::SharedMemoryInputs) = get(inp.user_idmap)
+item_idmap(inp::SharedMemoryInputs) = isnull(inp.item_idmap) ? Int64[] : get(inp.item_idmap)
+user_idmap(inp::SharedMemoryInputs) = isnull(inp.user_idmap) ? Int64[] : get(inp.user_idmap)
 
 nusers(inp::SharedMemoryInputs) = size(get(inp.R), 1)
 nitems(inp::SharedMemoryInputs) = size(get(inp.R), 2)


### PR DESCRIPTION
In preparation for implementing distributed memory computation, I have created abstractions for `Inputs` and `Model` types.

The current shared memory and thread computation use `SharedMemoryInputs` and `SharedMemoryModel` as their respective concrete implementations. Under the hood, the shared memory implementation uses `SparseMatrixCSC` and `Matrix` as before. Distributed memory computation would replace them with something else appropriate.

I find no performance regressions with the abstractions in place, and these would be useful for trying out different computation models. It would be good to merge this separately. Will follow this up with another PR for a distributed memory implementation.